### PR TITLE
Prevent auto zoom when tapped ISH on iOS

### DIFF
--- a/minamo-server/src/scss/terminal.scss
+++ b/minamo-server/src/scss/terminal.scss
@@ -27,12 +27,13 @@
 
   .xterm-viewport {
     background-color: transparent;
-  }
-
-  .xterm-viewport {
     width: 18px;
     overflow-x: hidden;
     margin-left: auto;
+  }
+
+  textarea.xterm-helper-textarea {
+    font-size: 16px;
   }
 
   .xterm {


### PR DESCRIPTION
Set textarea font size to 16px to prevent auto zoom on iOS.